### PR TITLE
Fixed bug in `Graphs.add_edge!` extension

### DIFF
--- a/src/GraphViews/hypergraph.jl
+++ b/src/GraphViews/hypergraph.jl
@@ -65,7 +65,7 @@ function Graphs.add_edge!(hypergraph::HyperGraph, hypernodes::HyperNode...)
     @assert length(hypernodes) > 1
     hypernodes = Set(collect(hypernodes))
     if Graphs.has_edge(hypergraph, hypernodes)
-        return get_hyperedge(hypernodes)
+        return get_hyperedge(hypergraph, hypernodes)
         #return hypergraph.hyperedges[hypernodes]
     else
         index = Graphs.ne(hypergraph) + 1


### PR DESCRIPTION
The extension of `Graphs.add_edge!` in GOI had an error where the `get_hyperedge` argument appears to be missing the `hypergraph` argument. I have updated it with this PR. 

This caused an error to be thrown when I tried to query the set of incident edges to a set of OptiNodes. When I updated this line of code, the error went away. 